### PR TITLE
Add virtual lab labels

### DIFF
--- a/app/fixtures.json
+++ b/app/fixtures.json
@@ -52,10 +52,35 @@
     }
   },
   {
+    "model": "virtual_labs.virtuallablabel",
+    "pk": 1,
+    "fields": {
+      "title": "label-1",
+      "color": "#a2eeef"
+    }
+  },
+  {
+    "model": "virtual_labs.virtuallablabel",
+    "pk": 2,
+    "fields": {
+      "title": "label-2",
+      "color": "#008672"
+    }
+  },
+  {
+    "model": "virtual_labs.virtuallablabel",
+    "pk": 3,
+    "fields": {
+      "title": "label-3",
+      "color": "#ffffff"
+    }
+  },
+  {
     "model": "virtual_labs.virtuallab",
     "pk": "fixture-virtual-lab-1",
     "fields": {
       "title": "fixture-virtual-lab-1",
+      "labels": [],
       "description": "",
       "created": "2024-10-16T13:05:39.474Z",
       "modified": "2024-10-16T13:05:39.474Z",
@@ -68,6 +93,10 @@
     "pk": "test-virtual-lab-1",
     "fields": {
       "title": "test-virtual-lab-1",
+      "labels": [
+        1,
+        2
+      ],
       "description": "",
       "created": "2024-10-16T13:05:39.474Z",
       "modified": "2024-10-16T13:05:39.474Z",
@@ -80,6 +109,10 @@
     "pk": "test-virtual-lab-2",
     "fields": {
       "title": "test-virtual-lab-2",
+      "labels": [
+        2,
+        3
+      ],
       "description": "",
       "created": "2024-10-16T13:05:39.474Z",
       "modified": "2024-10-16T13:05:39.474Z",

--- a/app/virtual_labs/admin.py
+++ b/app/virtual_labs/admin.py
@@ -2,4 +2,5 @@ from django.contrib import admin
 
 from . import models
 
+admin.site.register(models.VirtualLabLabel)
 admin.site.register(models.VirtualLab)

--- a/app/virtual_labs/models.py
+++ b/app/virtual_labs/models.py
@@ -1,9 +1,32 @@
 from django.db import models
+from django.core.validators import RegexValidator
+
+
+class VirtualLabLabel(models.Model):
+    title = models.CharField(
+        unique=True,
+        max_length=255,
+        help_text="The display name of the label.",
+        )
+    color = models.CharField(
+        max_length=7,
+        validators=[
+            RegexValidator(
+                regex=r'^#(?:[0-9a-fA-F]{3}){1,2}$',
+                message="Color must be a valid hex code, e.g., #FFF or #FFFFFF.",
+                )
+            ],
+        help_text="Color in hex format (e.g. #FFFFFF).",
+        )
+
+    def __str__(self):
+        return self.title
 
 
 class VirtualLab(models.Model):
     slug = models.SlugField(primary_key=True, unique=True)
     title = models.CharField(max_length=255)
+    labels = models.ManyToManyField("VirtualLabLabel", related_name="VirtualLabs", blank=True)
     description = models.TextField(blank=True)
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)

--- a/app/virtual_labs/serializers.py
+++ b/app/virtual_labs/serializers.py
@@ -3,8 +3,26 @@ from rest_framework import serializers
 from . import models
 
 
+class VirtualLabLabelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.VirtualLabLabel
+        fields = ['title', 'color']
+
+
 class VirtualLabSerializer(serializers.HyperlinkedModelSerializer):
+    labels = VirtualLabLabelSerializer(many=True, required=False)
+
     class Meta:
         model = models.VirtualLab
-        fields = ['url', 'slug', 'title', 'description', 'created', 'modified',
-                  'deployment_url', 'container_image', 'image']
+        fields = [
+            'url',
+            'slug',
+            'title',
+            'labels',
+            'description',
+            'created',
+            'modified',
+            'deployment_url',
+            'container_image',
+            'image',
+            ]

--- a/bruno/virtual-labs/Retrieve.bru
+++ b/bruno/virtual-labs/Retrieve.bru
@@ -20,10 +20,20 @@ tests {
   });
   test("JSON response is valid", function () {
       var jsonData = res.getBody();
-      expect(jsonData).to.include({
+      expect(jsonData).to.deep.include({
         // "url": "http://localhost:8000/virtual-labs/test-virtual-lab-1/",
         "slug": "test-virtual-lab-1",
         "title": "test-virtual-lab-1",
+        "labels": [
+          {
+            "title": "label-1",
+            "color": "#a2eeef"
+          },
+          {
+            "title": "label-2",
+            "color": "#008672"
+          }
+        ],
         "description": "",
         // "created": "2024-10-16T13:05:39.474000Z",
         // "modified": "2024-10-16T13:05:39.474000Z",


### PR DESCRIPTION
- Add a new `VirtualLabLabel` model with attributes `title` and `color`
- Add a `labels` attribute to `VirtualLab` model. Example serialized `VirtualLab` with labels:

  ```json
  {
    "url": "http://localhost:8000/NaaVRE-catalogue-service/virtual-labs/test-virtual-lab-1/",
    "slug": "test-virtual-lab-1",
    "title": "test-virtual-lab-1",
    "labels": [
      {
        "title": "label-1",
        "color": "#a2eeef"
      },
      {
        "title": "label-2",
        "color": "#008672"
      }
    ],
    "description": "",
    "created": "2024-10-16T13:05:39.474000Z",
    "modified": "2024-10-16T13:05:39.474000Z",
    "deployment_url": "",
    "container_image": "",
    "image": null
  }
  ```

- Add configuration needed to edit the label through the Django admin interface
